### PR TITLE
fixes linux build scripts and project.4coder for .lin

### DIFF
--- a/build-custom-linux.sh
+++ b/build-custom-linux.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 set -e
 

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 # -e exit when anything returns non-zero status
 # -u unset variables are an error, exit immediately
@@ -26,7 +26,7 @@ CUSTOM_BIN="$CUSTOM_ROOT/bin"
 
 echo "---"
 echo "Building Executable ..."
-sh "$BIN_ROOT/build-linux.sh" "-DDEV_BUILD" # "-DPACKAGE_SUPER_X64"
+"$BIN_ROOT/build-linux.sh" "-DDEV_BUILD" # "-DPACKAGE_SUPER_X64"
 
-sh "$PROJECT_ROOT/build-custom-linux.sh"
+"$PROJECT_ROOT/build-custom-linux.sh"
 

--- a/project.4coder
+++ b/project.4coder
@@ -35,7 +35,7 @@ load_paths = {
 commands = {
     .build_x64 = {
         .win = "echo build: x64 & build.bat",
-        .linux = "echo build: x64 && build-linux.sh",
+        .linux = "echo build: x64 && ./build-linux.sh",
         .mac = "echo build: x64 && build-mac.sh",
         .out = "*compilation*",
         .footer_panel = true,
@@ -44,7 +44,7 @@ commands = {
     },
     .build_custom_x64 = {
         .win = "echo build custom: x64 & build-custom.bat",
-        .linux = "echo build custom: x64 && build-custom-linux.sh",
+        .linux = "echo build custom: x64 && ./build-custom-linux.sh",
         .mac = "echo build custom: x64 && build-custom-mac.sh",
         .out = "*compilation*",
         .footer_panel = true,


### PR DESCRIPTION
minor changes to build scripts for linux

- there is no pushd/popd in sh
- changed all shebangs to use /usr/bin/env bash
- fixed project.4coder to use ./{scriptname} so the shell can find what to execute